### PR TITLE
CPE Negotiation. Vastly improve network connectivity

### DIFF
--- a/src/luma/classes/ServerPlayer.ts
+++ b/src/luma/classes/ServerPlayer.ts
@@ -4,6 +4,7 @@ import { Orientation } from "../util/Vectors/Orientation";
 import { Mobile } from "./Entity/EntityBase";
 import { MinecraftClassicServer } from "./MinecraftClassicServer";
 import { World } from "./World";
+import { CPE_ExtEntry } from "../packet_wrappers/IncomingPackets";
 
 
 
@@ -35,7 +36,6 @@ export interface WorldSafePlayer extends UnsafePlayer {
   connected: true
 }
 
-
 export class UnsafePlayer implements Mobile {
   
   public sendPacket(packet: Buffer): Promise<void> {
@@ -54,6 +54,7 @@ export class UnsafePlayer implements Mobile {
     })
   }
 
+  public partialPacketBuffer: Buffer | undefined
 
   public handleClose = true
   public connected = true
@@ -71,6 +72,9 @@ export class UnsafePlayer implements Mobile {
   private gameModeStorage = new Map<string, object>()
 
   public simuLatency = 0
+  public extensionCount = 0
+
+  public CPESupport: CPE_ExtEntry[] = [];
 
   public getStorage(identifier: string, defaultState: () => object) {
     if (this.gameModeStorage.has(identifier)) {

--- a/src/luma/enums/IncomingPacketType.ts
+++ b/src/luma/enums/IncomingPacketType.ts
@@ -1,8 +1,0 @@
-enum IncomingPacketType {
-  PlayerIdentification = 0x00,
-  SetBlock = 0x05,
-  PositionAndOrientation = 0x08,
-  Message = 0x0d
-}
-
-export default IncomingPacketType;

--- a/src/luma/packet_wrappers/IncomingPackets.ts
+++ b/src/luma/packet_wrappers/IncomingPackets.ts
@@ -2,7 +2,12 @@ import { unpack } from "python-struct"
 import { BlockFractionUnit, BlockUnit, MVec3 } from "../util/Vectors/MVec3"
 import { Orientation } from "../util/Vectors/Orientation"
 
-export class PlayerIdentification{
+//THIS MODULE MAY ONLY CONTAIN INCOMING PACKET HELPER CLASSES
+//ALL CLASSES IN THIS FILE MUST CONTAIN ID AND BYTES STATIC PROPERTIES
+//IT IS LATER USED TO AUTOMATE THE PROCESS OF PACKET IDENTIFICATION
+//TODO: make it so the above is not required. Probably refactor this whole file...
+
+export class PlayerIdentification {
   constructor(
     public username: string,
     public verificationKey: string,
@@ -12,6 +17,8 @@ export class PlayerIdentification{
     const data = unpack('>BB64s64sB', packet) as [number, number, string, string, number]
     return new this(data[2].trimEnd(), data[3].trimEnd(), data[4] == 0x42)
   }
+  static id = 0x00
+  static bytes = 131
 }
 
 export class PositionAndOrientation{
@@ -25,6 +32,9 @@ export class PositionAndOrientation{
     const data = unpack('>BBHHHBB', packet) as [number, number, BlockFractionUnit, BlockFractionUnit, BlockFractionUnit, number, number]
     return new this(data[1], new MVec3<BlockFractionUnit>( data[2], data[3], data[4] ), new Orientation(data[5], data[6])) 
   }
+
+  static id = 0x08
+  static bytes = 10
 }
 
 export class SetBlock{
@@ -38,6 +48,9 @@ export class SetBlock{
     const data = unpack('>BHHHBB', packet) as [number, BlockUnit, BlockUnit, BlockUnit, number, number]
     return new this(new MVec3<BlockUnit>(data[1], data[2], data[3]), data[4] == 1, data[5])
   }
+
+  static id = 0x05
+  static bytes = 9
 }
 
 export class Message {
@@ -49,4 +62,37 @@ export class Message {
     const data = unpack('>BB64s', packet) as [number, number, string]
     return new this(data[2].trimEnd())
   }
+
+  static id = 0x0d
+  static bytes = 66
+}
+
+export class CPE_ExtInfo {
+  constructor (
+    public appName: string,
+    public extensionCount: number
+  ) {}
+
+  static from(packet: Buffer) {
+    const data = unpack('>B64sH', packet) as [number, string, number]
+    return new this(data[1].trimEnd(), data[2])
+  }
+
+  static id = 0x10
+  static bytes = 67
+}
+
+export class CPE_ExtEntry {
+  constructor (
+    public extName: string,
+    public version: number
+  ) {}
+
+  static from(packet: Buffer) {
+    const data = unpack('>B64si', packet) as [number, string, number]
+    return new this(data[1].trimEnd(), data[2])
+  }
+
+  static id = 0x11
+  static bytes = 69
 }

--- a/src/luma/packet_wrappers/OutgoingPackets.ts
+++ b/src/luma/packet_wrappers/OutgoingPackets.ts
@@ -115,3 +115,23 @@ export function Message(text: string) {
 export function Ping() {
   return pack('>B', [0x01])
 }
+
+export function CPE_ExtInfo(extensionCount: number) {
+  const a = pack('>B64sH',[
+    0x10,
+    'Luma',
+    extensionCount
+  ])
+  console.log(dumpBufferToString(a))
+  return a
+}
+
+export function CPE_ExtEntry(name: string, version: number) {
+  const a = pack('>B64si', [ 
+    0x11, 
+    name, 
+    version
+  ])
+  console.log(dumpBufferToString(a))
+  return a
+}


### PR DESCRIPTION
This PR adds CPE negotiation procedure to the server. This should have been simple, however, multiple bugs have been discovered in the process and needed to be fixed.

- TCP packet coalescing made the server miss packets
- The server wasn't expecting partial packets at all

Therefore, the `clientSocket.on('data')` handler has been overhauled completely from a single call to `MinecraftClassicServer.handlePacket` to a proper packet reader:
- Now parses more than one packet per data chunk
- Now concatenates broken packets split into any amount of chunks
- Can do both at the same time