### PR TITLE
Block ticking early cpe

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,13 @@ Negotiates, pretends to implement EmoteFix, that's it.
 - [ ] "Luma Freebuild" game mode: what you're used to
 - [ ] Plugin system: let game modes be further extendable
 - [ ] Support, new nice things, etc...
+
+
+# Acknowledgements
+This project would have never reached any state if not for the following members of the ClassiCube discord:
+- Vexyl
+- AmogusPH
+- UnknownShadow200
+
+Special thanks to Markus "Notch" Persson for creating Minecraft (duh!)
+Your dirty laundry (the classic protocol) is so much fun to build upon!

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "bufferpack": "^0.0.6",
         "glob": "^9.3.2",
         "python-struct": "^1.1.3",
-        "ts-matrix": "^1.2.2"
+        "ts-matrix": "^1.2.2",
+        "zod": "^3.21.4"
       },
       "devDependencies": {
         "@types/node": "^18.15.3",
@@ -1717,6 +1718,14 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/zod": {
+      "version": "3.21.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.21.4.tgz",
+      "integrity": "sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
     }
   },
   "dependencies": {
@@ -2921,6 +2930,11 @@
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true
+    },
+    "zod": {
+      "version": "3.21.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.21.4.tgz",
+      "integrity": "sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw=="
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "classic-lua",
+  "name": "luma-classic-server",
   "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "classic-lua",
+      "name": "luma-classic-server",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "bufferpack": "^0.0.6",
     "glob": "^9.3.2",
     "python-struct": "^1.1.3",
-    "ts-matrix": "^1.2.2"
+    "ts-matrix": "^1.2.2",
+    "zod": "^3.21.4"
   },
   "devDependencies": {
     "@types/node": "^18.15.3",

--- a/src/gamemodes/Lobby/main.ts
+++ b/src/gamemodes/Lobby/main.ts
@@ -2,11 +2,13 @@ import { Socket } from "net";
 import { MinecraftClassicServer } from "../../luma/classes/MinecraftClassicServer";
 import { World } from "../../luma/classes/World";
 import { CommandEvent } from "../../luma/events/CommandEvent";
-import { SetBlockEvent } from "../../luma/events/SetBlockEvent";
 import { GameMode, GameModeMeta } from "../../luma/interfaces/GameMode";
 import * as OutgoingPackets from '../../luma/packet_wrappers/OutgoingPackets'
 import { createReadStream } from "fs";
 import { dumpBufferToString } from "../../luma/util/Helpers/HexDumper";
+import { TickEvent } from "../../luma/events/TickEvent";
+import { randInt } from "../../luma/util/Helpers/RandInt";
+import { BlockUnit, MVec3 } from "../../luma/util/Vectors/MVec3";
 
 export const meta: GameModeMeta = {
   identifier: 'luma-lobby',
@@ -30,6 +32,37 @@ export default class implements GameMode {
     //   console.log(`Denied block placement for ${evt.player}`)
     //   evt.deny()
     // })
+
+    world.on('tick', () => {
+      // console.log('ticked')
+      for (let i=0; i<64; i++) {
+        const pos = new MVec3<BlockUnit>(
+          randInt(world.sizeX) as BlockUnit,
+          randInt(world.sizeY) as BlockUnit,
+          randInt(world.sizeZ) as BlockUnit
+        )
+
+        const b = world.getBlockAtMVec3(pos)
+        if (b == Block.Vanilla.Wood) {
+          world.setBlockAtMVec3(
+            Block.Vanilla.Wood,
+            pos.sum(new MVec3<BlockUnit>(
+              0 as BlockUnit,
+              1 as BlockUnit,
+              0 as BlockUnit
+            ))
+          )
+        } else {
+          if (b != Block.Vanilla.Air) {
+            world.setBlockAtMVec3(
+              Block.Vanilla.Dirt,
+              pos
+            ) 
+          }
+        }
+      }
+    })
+
     server.on('command-lobby', (evt: CommandEvent) => {
       evt.deny(`Lobby gamemode handled a command! Params: ${evt.args.join(', ')}`)
     })

--- a/src/luma/classes/ServerPlayer.ts
+++ b/src/luma/classes/ServerPlayer.ts
@@ -75,6 +75,7 @@ export class UnsafePlayer implements Mobile {
   public extensionCount = 0
 
   public CPESupport: CPE_ExtEntry[] = [];
+  public CPESkipped: CPE_ExtEntry[] = [];
 
   public getStorage(identifier: string, defaultState: () => object) {
     if (this.gameModeStorage.has(identifier)) {
@@ -102,6 +103,12 @@ export class UnsafePlayer implements Mobile {
     const newId: number = await targetWorld.bindPlayer(this)
     console.log(`Bound new player to world, id ${newId}`)
 
+  }
+
+  public supports(extName: string, version = 1): boolean | CPE_ExtEntry {
+    return !! this.CPESupport.find( (supportedEntry) => {
+      return supportedEntry.extName == extName && supportedEntry.version == version
+    } )
   }
   
   

--- a/src/luma/classes/ServerPlayer.ts
+++ b/src/luma/classes/ServerPlayer.ts
@@ -37,6 +37,7 @@ export interface WorldSafePlayer extends UnsafePlayer {
 }
 
 export class UnsafePlayer implements Mobile {
+  public CPE = {} as {[x: string]: ((...args: never[]) => unknown) | undefined}
   
   public sendPacket(packet: Buffer): Promise<void> {
     return new Promise((resolve) => {
@@ -105,7 +106,7 @@ export class UnsafePlayer implements Mobile {
 
   }
 
-  public supports(extName: string, version = 1): boolean | CPE_ExtEntry {
+  public supports(extName: string, version = 1) {
     return !! this.CPESupport.find( (supportedEntry) => {
       return supportedEntry.extName == extName && supportedEntry.version == version
     } )

--- a/src/luma/classes/World.ts
+++ b/src/luma/classes/World.ts
@@ -10,6 +10,8 @@ import * as OutgoingPackets from "../packet_wrappers/OutgoingPackets"
 import { WorldJoinProcedure } from "../packet_wrappers/ComplexProcedures";
 import { PositionedBlockMap } from "../data_structures/BlockCollection";
 import { TickEvent } from "../events/TickEvent";
+import { BlockTickEvent } from "../events/BlockTickEvent";
+import { randInt } from "../util/Helpers/RandInt";
 
 interface WorldOptions {
   sizeX?: number,
@@ -30,6 +32,8 @@ export class World extends EventEmitter {
   public players = new Set<UnsafePlayer>()
   public entities = new Set<EntityBase>()
   private gamemode: GameMode | undefined
+
+  public tickPerChunk = 10;
 
   private idTracker = new EntityIdTracker(128)
 
@@ -59,7 +63,30 @@ export class World extends EventEmitter {
   }
 
   public tick(dt: number): TickInfo {
+    //Emit global tick
     this.emit('tick', new TickEvent(dt))
+    //Emit dedicated block tick events
+    for (let xPos = 0; xPos < this.sizeX; xPos+=16) {
+      for (let yPos = 0; yPos < this.sizeY; yPos+=16) {
+        for (let zPos = 0; zPos < this.sizeZ; zPos+=16) {
+
+          const tickPosition = new MVec3<BlockUnit>(
+            (xPos + randInt(16)) as BlockUnit,
+            (yPos + randInt(16)) as BlockUnit,
+            (zPos + randInt(16)) as BlockUnit
+          )
+
+          if (tickPosition.boundedBy(
+            MVec3.zeroBlock,
+            this.sizeMVec3
+          )) {
+            const blockId = this.getBlockAtMVec3(tickPosition)
+  
+            this.emit('block-tick', new BlockTickEvent(tickPosition, blockId))
+          }
+        }
+      }  
+    }
 
     const previousUpdates = this.blockUpdatesThisTick
     this.blockUpdatesThisTick = new PositionedBlockMap()
@@ -73,14 +100,22 @@ export class World extends EventEmitter {
     //width is X
     //depth is Z
     //XZY order (thanks, notch!)
-    return this.sizeY*this.sizeX*z + this.sizeX*y + x
+    return this.sizeY*this.sizeX*y + this.sizeX*z + x
   }
 
-  public getBlockAtPos(x: number, y: number, z: number): number {
+  private getBlockInternal(x: number, y: number, z: number): number {
     return this.blocks[this.blockIndex(x,y,z)]
   }
   public getBlockAtMVec3(position: MVec3<BlockUnit>): number {
-    return this.blocks[this.blockIndex(position.x, position.y, position.z)]
+    if (
+      position.x >= 0 && position.x < this.sizeX,
+      position.y >= 0 && position.y < this.sizeY,
+      position.z >= 0 && position.x < this.sizeZ
+    ) {
+      return this.blocks[this.blockIndex(position.x, position.y, position.z)]
+    } else {
+      return Block.Vanilla.Bedrock
+    }
   }
 
   private setBlockInternal(blockID: number, x: number, y: number, z: number) {
@@ -88,8 +123,14 @@ export class World extends EventEmitter {
   }
 
   public setBlockAtMVec3(blockID: number, position: MVec3<BlockUnit>) {
-    this.blocks[this.blockIndex(position.x, position.y, position.z)] = blockID
-    this.blockUpdatesThisTick.setBlock(position, blockID)
+    if (
+      position.x >= 0 && position.x < this.sizeX,
+      position.y >= 0 && position.y < this.sizeY,
+      position.z >= 0 && position.x < this.sizeZ
+    ) {
+      this.blocks[this.blockIndex(position.x, position.y, position.z)] = blockID
+      this.blockUpdatesThisTick.setBlock(position, blockID)
+    }
   }
 
   /**
@@ -119,7 +160,7 @@ export class World extends EventEmitter {
     for (let yPos = 0; yPos < this.sizeY; yPos++) {
       for (let zPos = 0; zPos < this.sizeZ; zPos++) {
         for (let xPos = 0; xPos < this.sizeX; xPos++) {
-          values.push(this.getBlockAtPos(xPos, yPos, zPos))
+          values.push(this.getBlockInternal(xPos, yPos, zPos))
         }
       }
     }
@@ -142,6 +183,8 @@ export class World extends EventEmitter {
   public readonly sizeZ: number;
   public readonly volume: number;
 
+  public readonly sizeMVec3: MVec3<BlockUnit>
+
   public spawnPoint: MVec3<BlockFractionUnit>
 
   constructor(options: WorldOptions) {
@@ -151,6 +194,11 @@ export class World extends EventEmitter {
     this.sizeY = options.sizeY || 64
     this.sizeZ = options.sizeZ || 64
     
+    this.sizeMVec3 = new MVec3<BlockUnit>(
+      this.sizeX as BlockUnit,
+      this.sizeY as BlockUnit,
+      this.sizeZ as BlockUnit
+    )
 
     this.spawnPoint = new MVec3<BlockFractionUnit>(16*32 as BlockFractionUnit, 16*32 as BlockFractionUnit, 16*32 as BlockFractionUnit)
 

--- a/src/luma/cpe_modules/CPE.ts
+++ b/src/luma/cpe_modules/CPE.ts
@@ -1,0 +1,18 @@
+import { UnsafePlayer } from "../classes/ServerPlayer"
+import { CPE_ExtEntry } from "../packet_wrappers/IncomingPackets"
+import { Mod_MessageTypes } from "./MessageType"
+
+export interface CPE_Mod<T extends UnsafePlayer>{
+  hydrate: ((player: UnsafePlayer) => void) | undefined
+  supportedBy(player: UnsafePlayer): player is T
+}
+
+interface CPESupportEntry<SupportGuard extends UnsafePlayer> extends CPE_ExtEntry {
+  mod: CPE_Mod<SupportGuard>
+}
+
+
+//This array lists all CPE modules supported by Luma software
+export const LumaCPESupportInfo: CPESupportEntry<unknown & UnsafePlayer>[] = [
+  {extName: 'MessageTypes', version: 1, mod: Mod_MessageTypes}
+]

--- a/src/luma/cpe_modules/MessageType.ts
+++ b/src/luma/cpe_modules/MessageType.ts
@@ -1,0 +1,40 @@
+import { pack } from "python-struct";
+import { UnsafePlayer } from "../classes/ServerPlayer";
+import { CPE_Mod } from "./CPE";
+
+interface MessageTypeSupportingPlayer extends UnsafePlayer {
+  CPE: {sendTypedMessage(msgType: MessageType, text: string): string}
+}
+
+
+export enum MessageType {
+  Chat,
+  Status1,
+  Status2,
+  Status3,
+  BottomRight1,
+  BottomRight2,
+  BottomRight3,
+  Announcement = 100
+}
+
+function packet_TypedOutgoingMessage(msgType: MessageType, text: string): Buffer {
+  return pack('>BB64s', [
+    0x0d,
+    msgType,
+    text.substring(0,64)
+  ])
+}
+
+export const Mod_MessageTypes: CPE_Mod<MessageTypeSupportingPlayer> = {
+  supportedBy(player: UnsafePlayer): player is MessageTypeSupportingPlayer {
+    return player.supports('MessageTypes', 1)
+  },
+  hydrate(player: UnsafePlayer) {
+    player.CPE.sendTypedMessage = (msgType: MessageType, text: string) => {
+      player.sendPacket(packet_TypedOutgoingMessage(msgType, text))
+      return "a"
+    }
+  }
+}
+

--- a/src/luma/data_structures/BlockCollection.ts
+++ b/src/luma/data_structures/BlockCollection.ts
@@ -1,0 +1,28 @@
+import { BlockUnit, MVec3 } from "../util/Vectors/MVec3";
+
+interface BlockCollectionEntry {
+  position: MVec3<BlockUnit>, 
+  blockId: number
+}
+
+export class PositionedBlockMap extends Map<string, BlockCollectionEntry> {
+
+  public setBlock(position: MVec3<BlockUnit>, blockId: number): void {
+    this.set(position.identity, {position, blockId})
+  }
+
+  public removeBlockAt(position: MVec3<BlockUnit>): void {
+    this.delete(position.identity)
+  }
+  
+  public hasBlockAt(position: MVec3<BlockUnit>): boolean {
+    return this.has(position.identity)
+  }
+
+  public getBlockAt(position: MVec3<BlockUnit>): BlockCollectionEntry {
+    const outBlock = this.get(position.identity)
+    if ( ! outBlock ) throw new Error('Given position does not exist in the block collection')
+    return outBlock
+  }
+
+}

--- a/src/luma/enums/MinecraftBlockID.ts
+++ b/src/luma/enums/MinecraftBlockID.ts
@@ -1,3 +1,6 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+/* eslint-disable @typescript-eslint/no-namespace */
+// Ambient type containing all block IDs
 namespace Block {
   export const enum Vanilla {
     Air,

--- a/src/luma/events/BlockTickEvent.ts
+++ b/src/luma/events/BlockTickEvent.ts
@@ -1,0 +1,8 @@
+import { BlockUnit, MVec3 } from "../util/Vectors/MVec3"
+
+export class BlockTickEvent {
+  constructor(
+    public position: MVec3<BlockUnit>,
+    public blockId: number
+  ) {}
+}

--- a/src/luma/events/TickEvent.ts
+++ b/src/luma/events/TickEvent.ts
@@ -1,0 +1,5 @@
+export class TickEvent {
+  constructor(
+    public dt: number
+  ) {}
+}

--- a/src/luma/util/Helpers/RandInt.ts
+++ b/src/luma/util/Helpers/RandInt.ts
@@ -1,3 +1,8 @@
 export function randInt(n: number) {
   return Math.floor(Math.random()*n)
 }
+
+export function randIntR(n: number, m: number) {
+  const delta = m - n;
+  return randInt(n) + randInt(delta)
+}

--- a/src/luma/util/Helpers/RandInt.ts
+++ b/src/luma/util/Helpers/RandInt.ts
@@ -1,0 +1,3 @@
+export function randInt(n: number) {
+  return Math.floor(Math.random()*n)
+}

--- a/src/luma/util/Vectors/MVec3.ts
+++ b/src/luma/util/Vectors/MVec3.ts
@@ -5,7 +5,7 @@ export type BlockFractionUnit = Nominal<number, 'BlockFractionUnit'>
 
 type MinecraftLengthUnit = BlockUnit | BlockFractionUnit
 
-/** A vec3 in Minecraft space. Immutable, methods return new MVec3. */
+/** A nominally typed vec3 in Minecraft space. Immutable, methods return new MVec3. */
 export class MVec3<NumberType extends MinecraftLengthUnit> {
 
   public readonly identity: string  
@@ -30,9 +30,17 @@ export class MVec3<NumberType extends MinecraftLengthUnit> {
 
   sum(other: MVec3<NumberType>) {
     return new MVec3<NumberType> (
-      this.internalX + other.internalX as NumberType,
-      this.internalY + other.internalY as NumberType,
-      this.internalZ + other.internalZ as NumberType,
+      this.internalX + other.internalX as NumberType, // i know "as NumberType" doesn't really make sense here
+      this.internalY + other.internalY as NumberType, // but we're dealing with make-believe nominal types in ts
+      this.internalZ + other.internalZ as NumberType, // so this is kind of required
+    )
+  }
+
+  offset(x: number,y: number,z: number) {
+    return new MVec3<NumberType>(
+      this.internalX + x as NumberType,
+      this.internalY + y as NumberType,
+      this.internalZ + z as NumberType
     )
   }
 
@@ -46,9 +54,9 @@ export class MVec3<NumberType extends MinecraftLengthUnit> {
 
   scaled(scale: number) {
     return new MVec3<NumberType> (
-      this.internalX * scale as NumberType, // i know "as TypedNumber" doesn't really make sense here
-      this.internalY * scale as NumberType, // but we're dealing with make-believe nominal types in ts
-      this.internalZ * scale as NumberType  // so this is kind of required
+      this.internalX * scale as NumberType, 
+      this.internalY * scale as NumberType, 
+      this.internalZ * scale as NumberType  
     )
   }
 
@@ -71,6 +79,20 @@ export class MVec3<NumberType extends MinecraftLengthUnit> {
       this.x == other.x && this.y == other.y && this.z == other.z
     )
   }
+
+  /** 
+   * Whether or not this MVec3 lands within the bounds created by a pair of other MVec3 
+   * */
+  public boundedBy(start: MVec3<NumberType>, end: MVec3<NumberType>) {
+    return (
+      this.internalX >= start.internalX && this.internalX <= end.internalX &&
+      this.internalY >= start.internalY && this.internalY <= end.internalY &&
+      this.internalZ >= start.internalZ && this.internalZ <= end.internalZ 
+    )
+  }
+
+  static zeroBlock = new MVec3<BlockUnit>(0 as BlockUnit,0 as BlockUnit,0 as BlockUnit)
+  static zeroFraction = new MVec3<BlockFractionUnit>(0 as BlockFractionUnit,0 as BlockFractionUnit,0 as BlockFractionUnit)
 }
 
 export function MVec3FractionToBlock(v: MVec3<BlockFractionUnit>){

--- a/src/luma/util/Vectors/MVec3.ts
+++ b/src/luma/util/Vectors/MVec3.ts
@@ -7,11 +7,15 @@ type MinecraftLengthUnit = BlockUnit | BlockFractionUnit
 
 /** A vec3 in Minecraft space. Immutable, methods return new MVec3. */
 export class MVec3<NumberType extends MinecraftLengthUnit> {
+
+  public readonly identity: string  
   constructor(
     public internalX: NumberType,
     public internalY: NumberType,
     public internalZ: NumberType
-  ) {}
+  ) {
+    this.identity = `${this.internalX} ${this.internalY} ${this.internalZ}`
+  }
 
   //As far as Minecraft is concerned, these are integers. Let's treat them appropriately.
   //We'll see how well this design decision goes


### PR DESCRIPTION
CPE modules are now loaded and CPE negotiation is performed properly

World ticking has been added. Available via `world.on('tick', (evt as TickEvent) => {})`
Supports variable tick rate.

Block ticking has been added. Available via `world.on('tick', (evt as BlockTickEvent) => {})`
A frivolous feature for implementing basic ticking mechanics fast and easy. Doesn't support variable tick rate, gonna iterate on this some more.

